### PR TITLE
fix(clippy) lint checks and docs for wasm32 target in order to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # proxy-wasm-filter-echo
 
-Add the wasm32 build target if needed
+Add the wasm32 build target if needed:
 
 ```
 $ rustup target add wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # proxy-wasm-filter-echo
 
+Add the wasm32 build target if needed
+
+```
+$ rustup target add wasm32-unknown-unknown
+```
+
 Build with:
 
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ impl HttpContext for HttpHeaders {
                  */
                 let (endpoint, path);
                 {
-                    let mut segments: Vec<&str> = p.split("/").collect::<Vec<&str>>().split_off(1);
+                    let mut segments: Vec<&str> = p.split('/').collect::<Vec<&str>>().split_off(1);
                     endpoint = segments.remove(0);
                     path = segments.join("/");
                 }
@@ -96,7 +96,7 @@ impl HttpContext for HttpHeaders {
                 match &endpoint as &str {
                     "headers" => {
                         let headers = self.get_http_request_headers();
-                        self.send_json_response(StatusCode::OK, Some(Headers { headers: headers }));
+                        self.send_json_response(StatusCode::OK, Some(Headers { headers }));
                     }
                     "user-agent" => {
                         #[derive(Serialize)]


### PR DESCRIPTION
This change accomplishes two things:
 - Adds documentation for how to add the necessary `wasm32-unknown-unknown` target to the toolchain
 - Fixes the following 2 clippy lint warnings (see the clippy warning output message urls for rationale):

```
14:07 $ cargo clippy
warning: redundant field names in struct initialization
  --> src/lib.rs:99:80
   |
99 |                         self.send_json_response(StatusCode::OK, Some(Headers { headers: headers }));
   |                                                                                ^^^^^^^^^^^^^^^^ help: replace it with: `headers`
   |
   = note: `#[warn(clippy::redundant_field_names)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: single-character string constant used as pattern
  --> src/lib.rs:91:59
   |
91 |                     let mut segments: Vec<&str> = p.split("/").collect::<Vec<&str>>().split_off(1);
   |                                                           ^^^ help: try using a `char` instead: `'/'`
   |
   = note: `#[warn(clippy::single_char_pattern)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: 2 warnings emitted
```